### PR TITLE
Fix mixpanel event name

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function VWOMixpanelPlugin(mixpanel){
                 mixpanel.track("VWO", _vis_data);
                 for (var i = 0; i < _vis_data["experiments"].length; i++) {
                     var experiment = _vis_data["experiments"][i];
-                    mixpanel.track("Experiment Started", {"Experiment name": experiment.eN, "Variant name": experiment.vN});
+                    mixpanel.track("$experiment_started", {"Experiment name": experiment.eN, "Variant name": experiment.vN});
                 }
 
                 mixpanel.people.set({


### PR DESCRIPTION
This PR is to fix the hard coded 'Experiment Started' event name.

Using the event named as 'Experiment Started' doesn't work with Mixpanel experiment tracking.
Mixpanel has an experiment started event (called $experiment_started) to be used by default. (It translates to 'Experiment Started' in the Mixpanel console)

Reference: https://docs.mixpanel.com/docs/reports/apps/experiments#add-experiments-to-an-implementation